### PR TITLE
Fix resync time in loop()

### DIFF
--- a/js/canvas-video-player.js
+++ b/js/canvas-video-player.js
@@ -230,8 +230,8 @@ CanvasVideoPlayer.prototype.loop = function() {
 	if(elapsed >= (1 / this.options.framesPerSecond)) {
 		this.video.currentTime = this.video.currentTime + elapsed;
 		this.lastTime = time;
-		// Resync audio and video if they drift more than 5ms apart
-		if(this.audio && Math.abs(this.audio.currentTime - this.video.currentTime) > 5){
+		// Resync audio and video if they drift more than 300ms apart
+		if(this.audio && Math.abs(this.audio.currentTime - this.video.currentTime) > .3){
 			this.audio.currentTime = this.video.currentTime;
 		}
 	}


### PR DESCRIPTION
HTML media elements keep track of time in seconds not milliseconds so updating this. 300ms is a pretty long lag threshold but anything too short causes high amounts of jitter.
