### PR TITLE
Added option to hold video on last frame once complete

### DIFF
--- a/js/canvas-video-player.js
+++ b/js/canvas-video-player.js
@@ -14,6 +14,7 @@ var CanvasVideoPlayer = function(options) {
 		autoplay: false,
 		audio: false,
 		timelineSelector: false,
+                resetOnLastFrame: true
 	};
 
 	for (i in options) {
@@ -239,7 +240,9 @@ CanvasVideoPlayer.prototype.loop = function() {
 	// If we are at the end of the video stop
 	if (this.video.currentTime >= this.video.duration) {
 		this.playing = false;
-		this.video.currentTime = 0;
+                if (this.options.resetOnLastFrame === true) {
+		        this.video.currentTime = 0;
+                }
 	}
 
 	if (this.playing) {


### PR DESCRIPTION
Hey there,

To replicate the native behaviour, when the HTML5 Video player finishes playing, it remains on the last frame.

When using this, it resets to the first frame which isn't always desirable, so I've added an option.

It may be the option could be refactored to specify a specific frame/time if not a boolean value but for the time being this solves my problem.

Hope this helps?

thanks
