### PR TITLE
Use the ended event listener instead of comparing currenttime and duration

### DIFF
--- a/js/canvas-video-player.js
+++ b/js/canvas-video-player.js
@@ -2,7 +2,8 @@ var cvpHandlers = {
 	canvasClickHandler: null,
 	videoTimeUpdateHandler: null,
 	videoCanPlayHandler: null,
-	windowResizeHandler: null
+	windowResizeHandler: null,
+       videoOnEndHandler: null
 };
 
 var CanvasVideoPlayer = function(options) {
@@ -177,6 +178,7 @@ CanvasVideoPlayer.prototype.bind = function() {
 		this.canvas.removeEventListener('click', cvpHandlers.canvasClickHandler);
 		this.video.removeEventListener('timeupdate', cvpHandlers.videoTimeUpdateHandler);
 		this.video.removeEventListener('canplay', cvpHandlers.videoCanPlayHandler);
+               this.video.removeEventListener('ended', cvpHandlers.videoOnEndHandler);
 		window.removeEventListener('resize', cvpHandlers.windowResizeHandler);
 
 		if (this.options.audio) {

--- a/js/canvas-video-player.js
+++ b/js/canvas-video-player.js
@@ -245,20 +245,6 @@ CanvasVideoPlayer.prototype.loop = function() {
 		}
 	}
 
-	// If we are at the end of the video stop
-	if (this.video.currentTime >= this.video.duration) {
-		this.playing = false;
-
-		if (this.options.resetOnLastFrame === true) {
-			this.video.currentTime = 0;
-		}
-
-		if (this.options.loop === true) {
-			this.video.currentTime = 0;
-			this.play();
-		}
-	}
-
 	if (this.playing) {
 		this.animationFrame = requestAnimationFrame(function(){
 			self.loop();


### PR DESCRIPTION
This fixes an issue when listening for the ended event on an instance of the video player.  The logic where the player compares currentime and duration to figure out if the video has ended prevents the ended event from triggering.