### PR TITLE
Custom Video Ended Event Name

### DIFF
--- a/js/canvas-video-player.js
+++ b/js/canvas-video-player.js
@@ -15,7 +15,8 @@ var CanvasVideoPlayer = function(options) {
 		audio: false,
 		timelineSelector: false,
 		resetOnLastFrame: true,
-		loop: false
+		loop: false,
+            	endedEventName: 'complete' // enabling users to setup their own event name on video ended.
 	};
 
 	for (i in options) {
@@ -246,6 +247,8 @@ CanvasVideoPlayer.prototype.loop = function() {
 	// If we are at the end of the video stop
 	if (this.video.currentTime >= this.video.duration) {
 		this.playing = false;
+		
+            	this.video.dispatchEvent(new Event(this.options.endedEventName));
 
 		if (this.options.resetOnLastFrame === true) {
 			this.video.currentTime = 0;

--- a/js/canvas-video-player.js
+++ b/js/canvas-video-player.js
@@ -252,7 +252,7 @@ CanvasVideoPlayer.prototype.loop = function() {
 			evt = document.createEvent('CustomEvent');
 			evt.initCustomEvent(this.options.endedEventName, true, true);
 		}
-		video.dispatchEvent(evt);
+		this.video.dispatchEvent(evt);
 		
 		if (this.options.resetOnLastFrame === true) {
 			this.video.currentTime = 0;


### PR DESCRIPTION
Added an option for users to customise video ended event name to their preference while preserving default "ended" event. This will be useful for users to create distinguishable video onended handlers in more complicated project.

Also, moved cvpHandlers into bind() function to minimise global variables.